### PR TITLE
:sparkles: Debugger support

### DIFF
--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -31,6 +31,7 @@ Chibi は Tampermonkey/GreasyMonkey に対応するユーザースクリプト�
 - [X] CodeLab
 - [X] 40code
 - [X] TurboWarp
+- [X] Xueersi
 
 # 🔥 使い方
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "private": true,
   "scripts": {
     "build": "NODE_ENV=production webpack --color --bail",
+    "dev": "NODE_ENV=development webpack --color --bail",
     "lint": "eslint ./src/ --ext .js,.ts,tsx,jsx",
+    "fix": "eslint ./src/ --ext .js,.ts,tsx,jsx --fix",
     "typecheck": "tsc --watch --noEmit"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build": "NODE_ENV=production webpack --color --bail",
     "dev": "NODE_ENV=development webpack --color --bail",
     "lint": "eslint ./src/ --ext .js,.ts,tsx,jsx",
-    "fix": "eslint ./src/ --ext .js,.ts,tsx,jsx --fix",
     "typecheck": "tsc --watch --noEmit"
   },
   "devDependencies": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="node_modules/@turbowarp/types/index.d.ts" />
-// <reference path="./loader/loader" />
-// <reference path="./loader/make-ctx" />
-// <reference path="./util/settings" />
+/// <reference path="./loader/loader" />
+/// <reference path="./loader/make-ctx" />
+/// <reference path="./util/settings" />
 
 declare interface Window {
     Blockly?: Partial<ScratchBlocks>;

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -152,8 +152,8 @@ export function inject (vm: ChibiCompatibleVM) {
                 if (window.chibi.settings.noConfirmDialog) {
                     whetherSideload = true;
                 } else {
-                    whetherSideload = env ?
-                        confirm(
+                    whetherSideload = env
+                        ? confirm(
                             format('chibi.tryLoadInEnv', {
                                 extensionURL,
                                 url,
@@ -273,11 +273,15 @@ export function inject (vm: ChibiCompatibleVM) {
                         const originalOpcode = block.mutation.proccode.trim().substring(14);
                         const extensionId = getExtensionIdForOpcode(originalOpcode);
                         if (!extensionId) {
-                            warn(`find a sideload block with an invalid id: ${originalOpcode}, ignored.`);
+                            warn(
+                                `find a sideload block with an invalid id: ${originalOpcode}, ignored.`
+                            );
                             continue;
                         }
                         if (!(extensionId in window.chibi.registeredExtension)) {
-                            warn(`find a sideload block with unregistered extension: ${extensionId}, ignored.`);
+                            warn(
+                                `find a sideload block with unregistered extension: ${extensionId}, ignored.`
+                            );
                             continue;
                         }
                         block.opcode = originalOpcode;
@@ -347,10 +351,6 @@ export function inject (vm: ChibiCompatibleVM) {
             return originalGetOrderFunc.call(this, extensions, ...args);
         };
     }
-    // Expose a context for developers.
-    if (!window.chibi.settings.dontExposeCtx) {
-        window.Scratch = makeCtx(vm);
-    }
     // Blockly stuffs
     vm.once('workspaceUpdate', () => {
         const blockly = (window.chibi.blockly = getBlocklyInstance(vm));
@@ -401,24 +401,28 @@ export function inject (vm: ChibiCompatibleVM) {
                 // Add temporarily load from file button
                 const sideloadTempButton = document.createElement('button');
                 sideloadTempButton.setAttribute('text', format('chibi.sideloadTemporarily'));
-                sideloadTempButton.setAttribute('callbackKey', 'CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY');
+                sideloadTempButton.setAttribute(
+                    'callbackKey',
+                    'CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY'
+                );
                 workspace.registerButtonCallback('CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY', () => {
                     const input = document.createElement('input');
                     input.setAttribute('type', 'file');
                     input.setAttribute('accept', '.js');
                     input.setAttribute('multiple', 'true');
-                    input.onchange = async (event: Event) => {
+                    input.addEventListener('change', async (event: Event) => {
                         const files = (event.target as HTMLInputElement).files;
                         if (!files) return;
                         for (const file of files) {
-                            const fileName = file.name;
-
-                            const url = URL.createObjectURL(file);
+                            const url = `data:text/javascript;charset=utf-8,${encodeURIComponent(
+                                await file.text()
+                            )}`;
                             const mode = confirm(format('chibi.loadInSandbox'))
-                                ? 'sandboxed' : 'unsandboxed';
+                                ? 'sandboxed'
+                                : 'unsandboxed';
                             window.chibi.loader.load(url, mode);
                         }
-                    };
+                    });
                     input.click();
                 });
                 xmlList.push(sideloadTempButton);
@@ -495,7 +499,8 @@ export function inject (vm: ChibiCompatibleVM) {
 
                         const url = URL.createObjectURL(file);
                         const mode = confirm(format('chibi.loadInSandbox'))
-                            ? 'sandboxed' : 'unsandboxed';
+                            ? 'sandboxed'
+                            : 'unsandboxed';
                         window.chibi.loader.load(url, mode);
                     }
                 };

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -278,8 +278,8 @@ export function inject (vm: ChibiCompatibleVM) {
                             warn(`find a sideload block with unregistered extension: ${extensionId}, ignored.`);
                             continue;
                         }
-	                    block.opcode = originalOpcode;
-	                    delete block.mutation;
+                        block.opcode = originalOpcode;
+                        delete block.mutation;
                     }
                 }
             }

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -36,7 +36,7 @@ const MAX_LISTENING_MS = 30 * 1000;
  * @param {!string} opcode The opcode to examine for extension.
  * @return {?string} The extension ID, if it exists and is not a core extension.
  */
-function getExtensionIdForOpcode(opcode: string) {
+function getExtensionIdForOpcode (opcode: string) {
     // Allowed ID characters are those matching the regular expression [\w-]: A-Z, a-z, 0-9, and hyphen ("-").
     const index = opcode.indexOf('_');
     const forbiddenSymbols = /[^\w-]/g;
@@ -49,9 +49,9 @@ function getExtensionIdForOpcode(opcode: string) {
  * @param vm Virtual machine instance. For some reasons we cannot use VM here.
  * @returns Blockly instance.
  */
-function getBlocklyInstance(vm: ChibiCompatibleVM): any | null {
+function getBlocklyInstance (vm: ChibiCompatibleVM): any | null {
     // Hijack Function.prototype.apply to get React element instance.
-    function hijack(fn: (...args: unknown[]) => unknown) {
+    function hijack (fn: (...args: unknown[]) => unknown) {
         const _orig = Function.prototype.apply;
         Function.prototype.apply = function (thisArg: any) {
             return thisArg;
@@ -88,7 +88,7 @@ function getBlocklyInstance(vm: ChibiCompatibleVM): any | null {
  * @param open window.open function (compatible with ccw).
  * @return Callback promise. After that you could use window.chibi.vm to get the virtual machine.
  */
-export function trap(open: typeof window.open): Promise<void> {
+export function trap (open: typeof window.open): Promise<void> {
     window.chibi = {
         // @ts-expect-error defined in webpack define plugin
         version: __CHIBI_VERSION__,
@@ -130,7 +130,7 @@ export function trap(open: typeof window.open): Promise<void> {
  * Inject into the original virtual machine.
  * @param vm {ChibiCompatibleVM} Original virtual machine instance.
  */
-export function inject(vm: ChibiCompatibleVM) {
+export function inject (vm: ChibiCompatibleVM) {
     const loader = (window.chibi.loader = new ChibiLoader(vm));
     const originalLoadFunc = vm.extensionManager.loadExtensionURL;
     const getLocale = vm.getLocale;
@@ -154,18 +154,18 @@ export function inject(vm: ChibiCompatibleVM) {
                 } else {
                     whetherSideload = env
                         ? confirm(
-                              format('chibi.tryLoadInEnv', {
-                                  extensionURL,
-                                  url,
-                                  env
-                              })
-                          )
+                            format('chibi.tryLoadInEnv', {
+                                extensionURL,
+                                url,
+                                env
+                            })
+                        )
                         : confirm(
-                              format('chibi.tryLoadInEnv', {
-                                  extensionURL,
-                                  url
-                              })
-                          );
+                            format('chibi.tryLoadInEnv', {
+                                extensionURL,
+                                url
+                            })
+                        );
                 }
                 if (whetherSideload) {
                     await loader.load(
@@ -173,8 +173,8 @@ export function inject(vm: ChibiCompatibleVM) {
                         (env
                             ? env
                             : confirm(format('chibi.loadInSandbox'))
-                            ? 'sandboxed'
-                            : 'unsandboxed') as 'unsandboxed' | 'sandboxed'
+                                ? 'sandboxed'
+                                : 'unsandboxed') as 'unsandboxed' | 'sandboxed'
                     );
                     const extensionId = loader.getIdByUrl(url);
                     // @ts-expect-error internal hack

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -491,24 +491,28 @@ export function inject (vm: ChibiCompatibleVM) {
             sideloadTempButton.setAttribute('text', format('chibi.sideloadTemporarily'));
             sideloadTempButton.setAttribute('callbackKey', 'CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY');
             workspace.registerButtonCallback('CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY', () => {
-                const input = document.createElement('input');
-                input.setAttribute('type', 'file');
-                input.setAttribute('accept', '.js');
-                input.setAttribute('multiple', 'true');
-                input.onchange = async (event: Event) => {
-                    const files = (event.target as HTMLInputElement).files;
-                    if (!files) return;
-                    for (const file of files) {
-                        const fileName = file.name;
-
-                        const url = URL.createObjectURL(file);
-                        const mode = confirm(format('chibi.loadInSandbox'))
-                            ? 'sandboxed'
-                            : 'unsandboxed';
-                        window.chibi.loader.load(url, mode);
-                    }
-                };
-                input.click();
+                if (prompt(format('chibi.exprimentalFileWarning'))) {
+                    const input = document.createElement('input');
+                    input.setAttribute('type', 'file');
+                    input.setAttribute('accept', '.js');
+                    input.setAttribute('multiple', 'true');
+                    input.addEventListener('change', async (event: Event) => {
+                        const files = (event.target as HTMLInputElement).files;
+                        if (!files) return;
+                        for (const file of files) {
+                            const url = URL.createObjectURL(file);
+                            const mode = confirm(format('chibi.loadInSandbox'))
+                                ? 'sandboxed'
+                                : 'unsandboxed';
+                            try {
+                                await window.chibi.loader.load(url, mode);
+                            } finally {
+                                URL.revokeObjectURL(url);
+                            }
+                        }
+                    });
+                    input.click();
+                }
             });
             xmlList.push(sideloadTempButton);
 

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -36,7 +36,7 @@ const MAX_LISTENING_MS = 30 * 1000;
  * @param {!string} opcode The opcode to examine for extension.
  * @return {?string} The extension ID, if it exists and is not a core extension.
  */
-function getExtensionIdForOpcode (opcode: string) {
+function getExtensionIdForOpcode(opcode: string) {
     // Allowed ID characters are those matching the regular expression [\w-]: A-Z, a-z, 0-9, and hyphen ("-").
     const index = opcode.indexOf('_');
     const forbiddenSymbols = /[^\w-]/g;
@@ -49,9 +49,9 @@ function getExtensionIdForOpcode (opcode: string) {
  * @param vm Virtual machine instance. For some reasons we cannot use VM here.
  * @returns Blockly instance.
  */
-function getBlocklyInstance (vm: ChibiCompatibleVM): any | null {
+function getBlocklyInstance(vm: ChibiCompatibleVM): any | null {
     // Hijack Function.prototype.apply to get React element instance.
-    function hijack (fn: (...args: unknown[]) => unknown) {
+    function hijack(fn: (...args: unknown[]) => unknown) {
         const _orig = Function.prototype.apply;
         Function.prototype.apply = function (thisArg: any) {
             return thisArg;
@@ -88,7 +88,7 @@ function getBlocklyInstance (vm: ChibiCompatibleVM): any | null {
  * @param open window.open function (compatible with ccw).
  * @return Callback promise. After that you could use window.chibi.vm to get the virtual machine.
  */
-export function trap (open: typeof window.open): Promise<void> {
+export function trap(open: typeof window.open): Promise<void> {
     window.chibi = {
         // @ts-expect-error defined in webpack define plugin
         version: __CHIBI_VERSION__,
@@ -130,7 +130,7 @@ export function trap (open: typeof window.open): Promise<void> {
  * Inject into the original virtual machine.
  * @param vm {ChibiCompatibleVM} Original virtual machine instance.
  */
-export function inject (vm: ChibiCompatibleVM) {
+export function inject(vm: ChibiCompatibleVM) {
     const loader = (window.chibi.loader = new ChibiLoader(vm));
     const originalLoadFunc = vm.extensionManager.loadExtensionURL;
     const getLocale = vm.getLocale;
@@ -154,18 +154,18 @@ export function inject (vm: ChibiCompatibleVM) {
                 } else {
                     whetherSideload = env
                         ? confirm(
-                            format('chibi.tryLoadInEnv', {
-                                extensionURL,
-                                url,
-                                env
-                            })
-                        )
+                              format('chibi.tryLoadInEnv', {
+                                  extensionURL,
+                                  url,
+                                  env
+                              })
+                          )
                         : confirm(
-                            format('chibi.tryLoadInEnv', {
-                                extensionURL,
-                                url
-                            })
-                        );
+                              format('chibi.tryLoadInEnv', {
+                                  extensionURL,
+                                  url
+                              })
+                          );
                 }
                 if (whetherSideload) {
                     await loader.load(
@@ -173,8 +173,8 @@ export function inject (vm: ChibiCompatibleVM) {
                         (env
                             ? env
                             : confirm(format('chibi.loadInSandbox'))
-                                ? 'sandboxed'
-                                : 'unsandboxed') as 'unsandboxed' | 'sandboxed'
+                            ? 'sandboxed'
+                            : 'unsandboxed') as 'unsandboxed' | 'sandboxed'
                     );
                     const extensionId = loader.getIdByUrl(url);
                     // @ts-expect-error internal hack
@@ -406,24 +406,28 @@ export function inject (vm: ChibiCompatibleVM) {
                     'CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY'
                 );
                 workspace.registerButtonCallback('CHIBI_SIDELOAD_FROM_FILE_TEMPORAILY', () => {
-                    const input = document.createElement('input');
-                    input.setAttribute('type', 'file');
-                    input.setAttribute('accept', '.js');
-                    input.setAttribute('multiple', 'true');
-                    input.addEventListener('change', async (event: Event) => {
-                        const files = (event.target as HTMLInputElement).files;
-                        if (!files) return;
-                        for (const file of files) {
-                            const url = `data:text/javascript;charset=utf-8,${encodeURIComponent(
-                                await file.text()
-                            )}`;
-                            const mode = confirm(format('chibi.loadInSandbox'))
-                                ? 'sandboxed'
-                                : 'unsandboxed';
-                            window.chibi.loader.load(url, mode);
-                        }
-                    });
-                    input.click();
+                    if (prompt(format('chibi.exprimentalFileWarning'))) {
+                        const input = document.createElement('input');
+                        input.setAttribute('type', 'file');
+                        input.setAttribute('accept', '.js');
+                        input.setAttribute('multiple', 'true');
+                        input.addEventListener('change', async (event: Event) => {
+                            const files = (event.target as HTMLInputElement).files;
+                            if (!files) return;
+                            for (const file of files) {
+                                const url = URL.createObjectURL(file);
+                                const mode = confirm(format('chibi.loadInSandbox'))
+                                    ? 'sandboxed'
+                                    : 'unsandboxed';
+                                try {
+                                    await window.chibi.loader.load(url, mode);
+                                } finally {
+                                    URL.revokeObjectURL(url);
+                                }
+                            }
+                        });
+                        input.click();
+                    }
                 });
                 xmlList.push(sideloadTempButton);
 

--- a/src/injector/inject.ts
+++ b/src/injector/inject.ts
@@ -7,6 +7,7 @@ import type VM from 'scratch-vm';
 import type Blockly from 'scratch-blocks';
 import * as l10n from '../l10n/l10n.json';
 import formatMessage from 'format-message';
+import { makeCtx } from '../loader/make-ctx';
 
 interface ChibiCompatibleWorkspace extends Blockly.Workspace {
     registerButtonCallback(key: string, callback: Function): void;
@@ -229,7 +230,7 @@ export function inject (vm: ChibiCompatibleVM) {
                         block.mutation.children = [];
                         block.mutation.tagName = 'mutation';
 
-	                    block.opcode = 'procedures_call';
+                        block.opcode = 'procedures_call';
                     }
                 }
             }
@@ -344,9 +345,12 @@ export function inject (vm: ChibiCompatibleVM) {
             return originalGetOrderFunc.call(this, extensions, ...args);
         };
     }
-
+    // Expose a context for developers.
+    if (!window.chibi.settings.dontExposeCtx) {
+        window.Scratch = makeCtx(vm);
+    }
     // Blockly stuffs
-    setTimeout(() => {
+    vm.once('workspaceUpdate', () => {
         const blockly = (window.chibi.blockly = getBlocklyInstance(vm));
         // Deprecated: this method will be removed in the future.
         if (!blockly) {
@@ -464,5 +468,5 @@ export function inject (vm: ChibiCompatibleVM) {
         const workspace = blockly.getMainWorkspace();
         workspace.getToolbox().refreshSelection();
         workspace.toolboxRefreshEnabled_ = true;
-    }, 3000);
+    });
 }

--- a/src/l10n/l10n.json
+++ b/src/l10n/l10n.json
@@ -1,29 +1,32 @@
 {
     "zh-cn": {
-        "chibi.openFrontend": "打开面板",
-        "chibi.sideload": "从 URL 侧载扩展",
-        "chibi.sideloadTemporarily": "从文件侧载扩展",
-        "chibi.errorIgnored": "在加载扩展扩展时出现错误。为了避免加载进程的中断，此错误已被忽略。",
+        "chibi.openFrontend": "🎨 打开面板",
+        "chibi.sideload": "🌏 从 URL 侧载扩展",
+        "chibi.sideloadTemporarily": "📄 从文件侧载扩展",
+        "chibi.errorIgnored": "❌ 在加载扩展扩展时出现错误。为了避免加载进程的中断，此错误已被忽略。",
+        "chibi.exprimentalFileWarning": "🛠️ 这是一项实验性功能 -- 刷新页面后插件将不可用。\n确定要继续么？",
         "chibi.tryLoad": "🤨 项目正从 {url} 加载扩展 {extensionURL}。要加载么？",
         "chibi.tryLoadInEnv": "🤨 项目正以 {env} 模式从 {url} 加载扩展 {extensionURL}。要加载么？",
         "chibi.loadInSandbox": "🤨 要在沙箱模式中加载扩展么？",
-        "chibi.enterURL": "🌐 输入 URL"
+        "chibi.enterURL": "🌐 输入 URL。"
     },
     "en": {
-        "chibi.openFrontend": "Open Frontend",
-        "chibi.sideload": "Sideload from URL",
-        "chibi.sideloadTemporarily": "Sideload from File",
-        "chibi.errorIgnored": "Error occurred while sideloading extension. To avoid interrupting the loading process, we chose to ignore this error.",
+        "chibi.openFrontend": "🎨 Open Frontend",
+        "chibi.sideload": "🌎 Sideload from URL",
+        "chibi.sideloadTemporarily": "📄 Sideload from File",
+        "chibi.errorIgnored": "❌ Error occurred while sideloading extension. To avoid interrupting the loading process, we chose to ignore this error.",
+        "chibi.exprimentalFileWarning": "🛠️ This is an experimental feature -- the extension will be unavailable after reloading.\nAre you sure you want to continue?",
         "chibi.tryLoad": "🤨 Project is trying to sideloading {extensionURL} from {url}. Do you want to load?",
         "chibi.tryLoadInEnv": "🤨 Project is trying to sideloading {extensionURL} from {url} in {env} mode. Do you want to load?",
         "chibi.loadInSandbox": "🤨 Do you want to load it in the sandbox?",
-        "chibi.enterURL": "🌐 Enter URL"
+        "chibi.enterURL": "🌐 Enter URL."
     },
     "ja": {
-        "chibi.openFrontend": "ダッシュボードを開く",
-        "chibi.sideload": "URL から拡張機能を導入",
-        "chibi.sideloadTemporarily": "ファイルから拡張機能を導入",
-        "chibi.errorIgnored": "拡張機能のサイドロード中でエラーが発生しました。ロードの中断を防ぐために、このエラーは無視しました。",
+        "chibi.openFrontend": "🎨 ダッシュボードを開く",
+        "chibi.sideload": "🌏 URL から拡張機能を導入",
+        "chibi.sideloadTemporarily": "📄 ファイルから拡張機能を導入",
+        "chibi.errorIgnored": "❌ 拡張機能のサイドロード中でエラーが発生しました。ロードの中断を防ぐために、このエラーは無視しました。",
+        "chibi.exprimentalFileWarning": "🛠️ これは実験機能であり -- ページをリロードしたら、拡張機能は使用できなくなります。\nよろしいですか？",
         "chibi.tryLoad": "🤨 プロジェクトは {url} から {extensionURL} をサイドロードしています。ロードしますか？",
         "chibi.tryLoadInEnv": "🤨 プロジェクトは {env} モードで、{url} から {extensionURL} をサイドロードしています。ロードしますか？",
         "chibi.loadInSandbox": "🤨 サンドボックス環境でロードしますか？",

--- a/src/l10n/l10n.json
+++ b/src/l10n/l10n.json
@@ -2,7 +2,7 @@
     "zh-cn": {
         "chibi.openFrontend": "打开面板",
         "chibi.sideload": "从 URL 侧载扩展",
-        "chibi.sideloadTemporarily": "从本地临时侧载扩展",
+        "chibi.sideloadTemporarily": "从文件侧载扩展",
         "chibi.errorIgnored": "在加载扩展扩展时出现错误。为了避免加载进程的中断，此错误已被忽略。",
         "chibi.tryLoad": "🤨 项目正从 {url} 加载扩展 {extensionURL}。要加载么？",
         "chibi.tryLoadInEnv": "🤨 项目正以 {env} 模式从 {url} 加载扩展 {extensionURL}。要加载么？",
@@ -12,7 +12,7 @@
     "en": {
         "chibi.openFrontend": "Open Frontend",
         "chibi.sideload": "Sideload from URL",
-        "chibi.sideloadTemporarily": "Sideload from File temporarily",
+        "chibi.sideloadTemporarily": "Sideload from File",
         "chibi.errorIgnored": "Error occurred while sideloading extension. To avoid interrupting the loading process, we chose to ignore this error.",
         "chibi.tryLoad": "🤨 Project is trying to sideloading {extensionURL} from {url}. Do you want to load?",
         "chibi.tryLoadInEnv": "🤨 Project is trying to sideloading {extensionURL} from {url} in {env} mode. Do you want to load?",
@@ -22,6 +22,7 @@
     "ja": {
         "chibi.openFrontend": "ダッシュボードを開く",
         "chibi.sideload": "URL から拡張機能を導入",
+        "chibi.sideloadTemporarily": "ファイルから拡張機能を導入",
         "chibi.errorIgnored": "拡張機能のサイドロード中でエラーが発生しました。ロードの中断を防ぐために、このエラーは無視しました。",
         "chibi.tryLoad": "🤨 プロジェクトは {url} から {extensionURL} をサイドロードしています。ロードしますか？",
         "chibi.tryLoadInEnv": "🤨 プロジェクトは {env} モードで、{url} から {extensionURL} をサイドロードしています。ロードしますか？",

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -39,7 +39,9 @@ export interface ScratchExtension {
  * @returns A promise to wait for the extensions to be loaded.
  */
 async function loadChibiExtension (extensionURL: string, ctx: Context): Promise<void> {
-    const resp = await fetch(extensionURL);
+    const resp = await fetch(extensionURL, {
+        cache: 'no-cache'
+    });
     const code = await resp.text();
     return new Promise<void>((resolve, reject) => {
         const elem = document.createElement('script') as ChibiCompatibleScript;

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -39,7 +39,7 @@ class UnsandboxedLoader {
      */
     loading: Promise<void> = Promise.resolve();
 
-    async load(extensionURL: string, ctx: Context) {
+    async load (extensionURL: string, ctx: Context) {
         return (this.loading = this.loading.then(() => {
             return (async () => {
                 try {
@@ -122,7 +122,7 @@ class ChibiLoader {
      */
     loadedScratchExtension = new Map<string, ScratchExtension>();
 
-    constructor(vm: VM) {
+    constructor (vm: VM) {
         this.vm = vm;
         dispatch.setService('loader', this).catch((e: Error) => {
             error(`ChibiLoader was unable to register extension service: ${JSON.stringify(e)}`);
@@ -134,7 +134,7 @@ class ChibiLoader {
      * @param {ExtensionClass | string} ext - Extension's data.
      * @param {'sandboxed' | 'unsandboxed'} env - Extension's running environment.
      */
-    async load(ext: string | ExtensionClass, env: 'sandboxed' | 'unsandboxed' = 'sandboxed') {
+    async load (ext: string | ExtensionClass, env: 'sandboxed' | 'unsandboxed' = 'sandboxed') {
         if (typeof ext === 'string') {
             switch (env) {
                 case 'sandboxed':
@@ -182,7 +182,7 @@ class ChibiLoader {
      * Reload a scratch-standard extension.
      * @param {string} extensionId - Extension's ID
      */
-    async reload(extensionId: string) {
+    async reload (extensionId: string) {
         const targetExt = this.loadedScratchExtension.get(extensionId);
         if (!targetExt) {
             throw new Error(`Cannot locate extension ${extensionId}.`);
@@ -202,7 +202,7 @@ class ChibiLoader {
         return info;
     }
 
-    getIdByUrl(url: string) {
+    getIdByUrl (url: string) {
         for (const [extId, ext] of this.loadedScratchExtension.entries()) {
             if (ext.url === url) {
                 return extId;
@@ -216,7 +216,7 @@ class ChibiLoader {
      *  original extension manager to reload locales. It should
      * be replaced when there's a better solution.
      */
-    reloadAll() {
+    reloadAll () {
         const allPromises: Promise<ExtensionMetadata | void>[] = [];
         for (const [extId] of this.loadedScratchExtension.entries()) {
             allPromises.push(this.reload(extId));
@@ -231,7 +231,7 @@ class ChibiLoader {
      * @param {string} serviceName - the name of the service hosting the extension
      * @private
      */
-    private _registerExtensionInfo(
+    private _registerExtensionInfo (
         extensionObject: ExtensionClass | null,
         extensionInfo: ExtensionMetadata,
         extensionURL: string,
@@ -263,7 +263,7 @@ class ChibiLoader {
      * @returns {string} - the sanitized text
      * @private
      */
-    private _sanitizeID(text: string) {
+    private _sanitizeID (text: string) {
         return text.toString().replace(/[<"&]/, '_');
     }
 
@@ -276,7 +276,7 @@ class ChibiLoader {
      * @returns {ExtensionInfo} - a new extension info object with cleaned-up values
      * @private
      */
-    private _prepareExtensionInfo(
+    private _prepareExtensionInfo (
         extensionObject: ExtensionClass | null,
         extensionInfo: ExtensionMetadata,
         serviceName?: string
@@ -334,7 +334,7 @@ class ChibiLoader {
      * @returns {Array.<MenuInfo>} - a menuInfo object with all preprocessing done.
      * @private
      */
-    private _prepareMenuInfo(
+    private _prepareMenuInfo (
         extensionObject: ExtensionClass | null,
         menus: Record<string, ExtensionMenu>,
         serviceName?: string
@@ -381,7 +381,7 @@ class ChibiLoader {
      * @returns {Array} menu items ready for scratch-blocks.
      * @private
      */
-    private _getExtensionMenuItems(
+    private _getExtensionMenuItems (
         extensionObject: ExtensionClass,
         menuItemFunctionName: string,
         serviceName?: string
@@ -427,7 +427,7 @@ class ChibiLoader {
      * @returns {ExtensionBlockMetadata} - a new block info object which has values for all relevant optional fields.
      * @private
      */
-    private _prepareBlockInfo(
+    private _prepareBlockInfo (
         extensionObject: ExtensionClass | null,
         blockInfo: ExtensionBlockMetadata,
         serviceName?: string
@@ -512,7 +512,7 @@ class ChibiLoader {
         return blockInfo;
     }
 
-    async updateLocales() {
+    async updateLocales () {
         await this.reloadAll();
     }
 
@@ -520,11 +520,11 @@ class ChibiLoader {
      * Regenerate blockinfo for any loaded extensions
      * @returns {Promise} resolved once all the extensions have been reinitialized
      */
-    async refreshBlocks() {
+    async refreshBlocks () {
         await this.reloadAll();
     }
 
-    allocateWorker() {
+    allocateWorker () {
         const workerInfo = this.pendingExtensions.shift();
         if (!workerInfo) {
             warn('pending extension queue is empty');
@@ -539,7 +539,7 @@ class ChibiLoader {
      * Collect extension metadata from the specified service and begin the extension registration process.
      * @param {string} serviceName - the name of the service hosting the extension.
      */
-    async registerExtensionService(extensionURL: string, serviceName: string) {
+    async registerExtensionService (extensionURL: string, serviceName: string) {
         const info = await dispatch.call(serviceName, 'getInfo');
         this._registerExtensionInfo(null, info, extensionURL, serviceName);
     }
@@ -549,7 +549,7 @@ class ChibiLoader {
      * @param {int} id - the worker ID.
      * @param {*?} e - the error encountered during initialization, if any.
      */
-    onWorkerInit(id: number, e?: Error) {
+    onWorkerInit (id: number, e?: Error) {
         const workerInfo = this.pendingWorkers[id];
         delete this.pendingWorkers[id];
         if (e) {

--- a/src/loader/sandbox.worker.ts
+++ b/src/loader/sandbox.worker.ts
@@ -4,7 +4,7 @@ import { WorkerDispatch as dispatch } from './dispatch/worker-dispatch';
 
 declare global {
     // eslint-disable-next-line no-var
-    var Scratch: Context;
+    var Scratch: Context | undefined;
 }
 /**
  * Here we implements a Worker dispatcher for sandboxed extensions.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { UserscriptPlugin } = require('webpack-userscript');
 const packageJSON = require('./package.json');
 const process = require('node:process');
-var __dirname;
 
 function getMatchURL () {
     const url = [
@@ -35,6 +34,7 @@ const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     entry: './src/index.ts',
     output: {
+        // eslint-disable-next-line no-undef
         path: path.resolve(__dirname, 'dist'),
         publicPath: './',
         filename: 'chibi.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,33 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { UserscriptPlugin } = require('webpack-userscript');
 const packageJSON = require('./package.json');
+const process = require('node:process');
+var __dirname;
 
+function getMatchURL () {
+    const url = [
+        'https://scratch.mit.edu/projects/*',
+        'https://aerfaying.com/Projects/*',
+        'https://www.ccw.site/*',
+        'https://gitblock.cn/Projects/*',
+        'https://world.xiaomawang.com/*',
+        'https://cocrea.world/*',
+        'https://create.codelab.club/*',
+        'https://www.scratch-cn.cn/*',
+        'https://www.40code.com/*',
+        'https://turbowarp.org/*',
+        'https://codingclip.com/*',
+        'https://editor.turbowarp.cn/*',
+        'https://0832.ink/rc/*',
+        'https://code.xueersi.com/scratch3/*',
+        'https://code.xueersi.com/home/project/detail?lang=scratch&pid=*&version=3.0&langType=scratch'
+    ];
+    if (process.env.NODE_ENV === 'development') {
+        url.unshift('http://localhost:8601/*');
+        return { include: url };
+    }
+    return { match: url };
+}
 const base = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     entry: './src/index.ts',
@@ -30,9 +56,7 @@ const base = {
             },
             {
                 test: /\.tsx?/,
-                use: [
-                    'babel-loader'
-                ],
+                use: ['babel-loader'],
                 exclude: /node_moudles/
             },
             {
@@ -43,15 +67,14 @@ const base = {
                 test: /\.svg$/,
                 type: 'asset/inline',
                 generator: {
-                    dataUrl: content =>
-                        svgToMiniDataURI(content.toString())
+                    dataUrl: (content) => svgToMiniDataURI(content.toString())
                 }
             }
         ]
     },
     plugins: [
         new UserscriptPlugin({
-            headers: {
+            headers: Object.assign({
                 name: packageJSON.displayName,
                 author: packageJSON.author,
                 namespace: 'ScratchChibiLoader',
@@ -61,31 +84,13 @@ const base = {
                 license: packageJSON.license,
                 grant: ['none'],
                 'run-at': 'document-start',
-                include: [
-                    'http://localhost:8601/*',
-                    'https://scratch.mit.edu/projects/*',
-                    'https://aerfaying.com/Projects/*',
-                    'https://www.ccw.site/*', 
-                    'https://gitblock.cn/Projects/*',
-                    'https://world.xiaomawang.com/*',
-                    'https://cocrea.world/*',
-                    'https://create.codelab.club/*',
-                    'https://www.scratch-cn.cn/*',
-                    'https://www.40code.com/*',
-                    'https://turbowarp.org/*',
-                    'https://codingclip.com/*',
-                    'https://editor.turbowarp.cn/*',
-                    'https://0832.ink/rc/*',
-                    'https://code.xueersi.com/scratch3/*',
-                    'https://code.xueersi.com/home/project/detail?lang=scratch&pid=*&version=3.0&langType=scratch'
-                ]
-            },
+            }, getMatchURL()),
             pretty: true,
             strict: true,
             whitelist: true
         }),
         new webpack.DefinePlugin({
-            '__CHIBI_VERSION__': JSON.stringify(packageJSON.version)
+            __CHIBI_VERSION__: JSON.stringify(packageJSON.version)
         })
     ]
 };


### PR DESCRIPTION
# Updates

- ✅ (Inspired by Gandi) Extension ESM support
- 🔍 Full debugger (DevTool inspect) support
- 🌟 (Zero delay, no need to wait 5 seconds) new trigger to get `Blockly`
- 🥇 Some extra refactors

🚧 Implements #6.