### PR TITLE
✨ feat: add new TurboWarp CN support and removed * from ElectraMod and XPlab 

### DIFF
--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -35,10 +35,8 @@ Eureka は Tampermonkey/GreasyMonkey に対応するユーザースクリプト�
 - [x] Creaticode
 - [x] Adacraft
 - [x] PenguinMod
-- [x] ElectraMod *
-- [x] XPLab *
-
-*\*: CI ビルドだけ使用できます*
+- [x] ElectraMod
+- [x] XPLab
 
 # 🔥 使い方
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -31,8 +31,8 @@ Eureka 是一个用户脚本，可以在任何基于 Scratch 的编辑器中加�
 - [x] Creaticode
 - [x] Adacraft
 - [x] PenguinMod
-- [x] ElectraMod *
-- [x] XPLab *
+- [x] ElectraMod
+- [x] XPLab
 
 # 🔥 使用方法
 1. 安装一个用户脚本管理器扩展, 例如 Tampermonkey 或 Greasymonkey。

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -34,8 +34,6 @@ Eureka 是一个用户脚本，可以在任何基于 Scratch 的编辑器中加�
 - [x] ElectraMod *
 - [x] XPLab *
 
-*\*: 仅在 CI 构建中可用*
-
 # 🔥 使用方法
 1. 安装一个用户脚本管理器扩展, 例如 Tampermonkey 或 Greasymonkey。
 2. 打开[发布页](https://github.com/EurekaScratch/eureka-loader/releases), 点击一个版本来安装。

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Eureka is a userscript which can load 3rd-party extensions in any Scratch-based 
 - [x] Creaticode
 - [x] Adacraft
 - [x] PenguinMod
-- [x] ElectraMod *
-- [x] XPLab *
+- [x] ElectraMod
+- [x] XPLab
 
 # 🔥 Usage
 1. Install UserScript Manager like Tampermonkey or Greasymonkey.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Eureka is a userscript which can load 3rd-party extensions in any Scratch-based 
 - [x] ElectraMod *
 - [x] XPLab *
 
-*\*: only available in ci builds*
-
 # 🔥 Usage
 1. Install UserScript Manager like Tampermonkey or Greasymonkey.
 2. Open [release](https://github.com/EurekaScratch/eureka-loader/releases), Then click one release to install.

--- a/generate-helper.js
+++ b/generate-helper.js
@@ -11,6 +11,7 @@ const includeURLs = [
     'https://turbowarp.org/*',
     'https://codingclip.com/*',
     'https://editor.turbowarp.cn/*',
+    'https://turbowarp.cn/*',
     'https://0832.ink/rc/*',
     'https://code.xueersi.com/scratch3/*',
     'https://play.creaticode.com/projects/*',


### PR DESCRIPTION
I have added the new TurboWarp CN website because Eureka only works with the old one. Additionally, I removed the asterisk (*) for ElectraMod and XPlab because they are available on Charlotte too, not just in CI builds. Could you please merge my pull request please?