### PR TITLE
🔧 chore: remove turbowarp.cn and add mirror.turbowarp.xyz

### DIFF
--- a/src/main/meta.js
+++ b/src/main/meta.js
@@ -18,8 +18,8 @@
 // @match       https://turbowarp.org/*
 // @match       https://staging.turbowarp.org/*
 // @match       https://experiments.turbowarp.org/*/*
+// @match       https://mirror.turbowarp.xyz/*
 // @match       https://codingclip.com/*
-// @match       https://editor.turbowarp.cn/*
 // @match       https://0832.ink/rc/*
 // @match       https://code.xueersi.com/*
 // @match       https://play.creaticode.com/*


### PR DESCRIPTION
turbowarp.cn has been down for.. quite some time, and the mirror has existed for a while so I don't know why it wasn't added at the start lol